### PR TITLE
Sessions bugfix

### DIFF
--- a/devfest-site/pages/SessionsPages.py
+++ b/devfest-site/pages/SessionsPages.py
@@ -48,7 +48,8 @@ class SessionsEditPage(FrontendPage):
       for s in sessions:
         s.session = str(s.key())
         s.slot_key = str(s.slot.key())
-        s.track_key = str(s.track.key())
+        if s.track:
+          s.track_key = str(s.track.key())
       # get list of event tracks
       tracks = CTrackList(event_id).get()
       for t in tracks:

--- a/devfest-site/templates/event_base.html
+++ b/devfest-site/templates/event_base.html
@@ -178,7 +178,7 @@ function clone_field_list(name) {
     <div class="span3">
       <div class="row">
         <span style="margin-left: 5px">
-          {% if event.logo %}
+          {% if event and event.logo %}
         <img src="/blob/{{event.logo}}">
         {% else %}
         <img src="/images/gdgbig.png">

--- a/devfest-site/templates/single_event_agenda.html
+++ b/devfest-site/templates/single_event_agenda.html
@@ -82,7 +82,11 @@
          </td>
          <td class="track">
                         
+         {% if session and session.track %}
          {% set track = track_list.get_for_key(session.track.key()) %}
+         {% else %}
+         {% set track = none %}
+         {% endif %}
          {% if track is not none %}
            {% set icon_url = track_list.get_icon_url(track) %}                          
            {% if icon_url is not none %}           


### PR DESCRIPTION
There are issues with the session editing & display.
When a session has no track assigned (which at the beginning is necessary: no tracks are defined) one cannot edit the tracks and cannot display the agenda.
This should work with the fix.
