### PR TITLE
migration from reference to str-key (session)

### DIFF
--- a/devfest-site/index.py
+++ b/devfest-site/index.py
@@ -13,6 +13,7 @@ from pages.SessionsPages import *
 from pages.RegisterPage import *
 from pages.JsonPages import *
 from pages.SlotsPages import *
+from pages.MigratePage import *
 
 app = webapp2.WSGIApplication([
                               ('^/logout$', LogoutPage),
@@ -61,6 +62,7 @@ app = webapp2.WSGIApplication([
                               ('^/register$', RegisterFormPage),
                               ('^/contact$', ContactPage),
                               ('^/blob/(.*)$', BlobPage),
+                              ('^/migrate$', MigratePage),
                               ('^/.*$', NotFoundPage),
                               ],
                               debug=False)

--- a/devfest-site/lib/cobjects.py
+++ b/devfest-site/lib/cobjects.py
@@ -265,7 +265,10 @@ class CSessionList(DbCachedObject):
   def load_from_db(self):
     sessions = Session.all().filter('event_key =', str(self.id))
     # I have to manually sort them, sorry...
-    self.entity_collection = sorted(sessions, key=lambda x: CSlot(x.slot_key).get().start)
+    try:
+      self.entity_collection = sorted(sessions, key=lambda x: CSlot(x.slot_key).get().start)
+    except:
+      self.entity_collection = sessions
 
 # list of sessions per event grouped by slots and rooms
 class CSessionAgendaList(OCachedObject):
@@ -309,6 +312,8 @@ class CSessionAgendaList(OCachedObject):
       # get the slot from the slot_key
       try:
         slot = CSlot(session.slot_key).get()
+        if not slot:
+          continue
       except:
         # we won't be able to display this session anyway
         continue

--- a/devfest-site/lib/forms.py
+++ b/devfest-site/lib/forms.py
@@ -135,7 +135,7 @@ class SingleSessionForm(Form):
   live_url        = TextField('URL of Live Stream')
   youtube_url     = TextField('URL on Youtube')
     # this field will get its choices specified dynamically
-  speakers        = MultiCheckboxField('Speakers')
+  speakers_key    = MultiCheckboxField('Speakers')
 
 # subform: a track - used in event-tracks form
 class SingleTrackForm(Form):

--- a/devfest-site/lib/model.py
+++ b/devfest-site/lib/model.py
@@ -178,16 +178,20 @@ class Session(db.Model):
   title       = db.StringProperty()
   abstract    = db.TextProperty()
   slot        = db.ReferenceProperty(Slot)
+  slot_key    = db.StringProperty()
   room        = db.StringProperty()
   level       = db.StringProperty()
   track       = db.ReferenceProperty(Track)
+  track_key   = db.StringProperty()
   live_url    = db.StringProperty()
   youtube_url = db.StringProperty()
   speakers    = db.ListProperty(db.Key)
+  speakers_key = db.StringListProperty()
   # OK, I know this violates "normalized" DB best practice.
   # a slot belongs to an event so I know already the event.
   # but for fast access I duplicate the information here as well.
   event       = db.ReferenceProperty(Event)
+  event_key   = db.StringProperty()
 
 class Speaker(db.Model):
   first_name  = db.StringProperty()
@@ -197,5 +201,4 @@ class Speaker(db.Model):
   thumbnail   = db.StringProperty()
   short_bio   = db.TextProperty()
   event       = db.ReferenceProperty(Event)
-
 

--- a/devfest-site/pages/JsonPages.py
+++ b/devfest-site/pages/JsonPages.py
@@ -103,17 +103,29 @@ class JsonTrackListPage(JSONPage):
 class JsonSessionListPage(JSONPage):
   def show(self, event_id):
     response = []
+    # prepare tracks
+    tracks = CTrackList(event_id).get()
+    track_for_key = { str(t.key) : t for t in tracks }
+    # prepare slots
+    slots = CSlotList(event_id).get()
+    slot_for_key = { str(s.key) : s for s in slots }
     for session in CSessionList(event_id).get():
       se = { 'title': session.title,
              'abstract': session.abstract,
-             'start': session.slot.start.isoformat(),
-             'end': session.slot.end.isoformat(),
              'room': session.room,
              'level': session.level,
-             'track': session.track.name,
              'live_url': session.live_url,
              'youtube_url': session.youtube_url,
-             'speakers': [ str(key) for key in session.speakers ]
+             'speakers': session.speakers_key
            }
+      try:
+        se.track = track_for_key[session.track_key].name
+      except:
+        pass
+      try:
+        se.start = slot_for_key[session.slot_key].start.isoformat()
+        se.end = slot_for_key[session.slot_key].end.isoformat()
+      except:
+        pass
       response.append(se)
     self.values["response"] = response

--- a/devfest-site/pages/MigratePage.py
+++ b/devfest-site/pages/MigratePage.py
@@ -1,0 +1,45 @@
+from lib.view import JSONPage
+from google.appengine.api import memcache
+from google.appengine.ext import db
+from lib.model import Session
+
+class MigratePage(JSONPage):
+  def show(self):
+    # return json of migrated data
+    response = []
+    # clear memcache
+    memcache.flush_all()
+    # get all sessions
+    sessions = Session.all()
+    for session in sessions:
+      s = { 'name' : session.title }
+      if not session.track_key:
+        try:
+          session.track_key = str(Session.track.get_value_for_datastore(session))
+          s['track'] = session.track_key
+        except:
+          pass
+      if not session.slot_key:
+        try:
+          session.slot_key = str(Session.slot.get_value_for_datastore(session))
+          s['slot'] = session.slot_key
+        except:
+          pass
+      if not session.speakers_key or len(session.speakers_key) == 0:
+        session.speakers_key = []
+        try:
+          for s in session.speakers:
+            session.speakers_key.append(str(s.key()))
+          s['speakers'] = session.speakers_key
+        except:
+          pass
+      if not session.event_key:
+        try:
+          session.event_key = str(Session.event.get_value_for_datastore(session))
+          s['event'] = session.event_key
+        except:
+          pass
+      # write back the session
+      session.put()
+      response.append(s)
+    self.values['response'] = response

--- a/devfest-site/pages/MigratePage.py
+++ b/devfest-site/pages/MigratePage.py
@@ -25,11 +25,14 @@ class MigratePage(JSONPage):
           s['slot'] = session.slot_key
         except:
           pass
-      if not session.speakers_key or len(session.speakers_key) == 0:
+      if not session.speakers_key:
         session.speakers_key = []
         try:
-          for s in session.speakers:
-            session.speakers_key.append(str(s.key()))
+          for sp in session.speakers:
+            try:
+              session.speakers_key.append(str(sp))
+            except:
+              pass
           s['speakers'] = session.speakers_key
         except:
           pass

--- a/devfest-site/pages/SessionsPages.py
+++ b/devfest-site/pages/SessionsPages.py
@@ -17,7 +17,7 @@ class SessionFormHelper:
   def add_speakers(form,speakers):
     # now iterate through the sessions fields in the form
     for session_form in form.sessions.entries:
-      session_form.speakers.choices = [ (str(sp.key()), sp.first_name + " " + sp.last_name) for sp in speakers ]
+      session_form.speakers_key.choices = [ (str(sp.key()), sp.first_name + " " + sp.last_name) for sp in speakers ]
       
   @staticmethod
   def add_slots(form,slots):
@@ -47,9 +47,6 @@ class SessionsEditPage(FrontendPage):
       sessions = CSessionList(event_id).get()
       for s in sessions:
         s.session = str(s.key())
-        s.slot_key = str(s.slot.key())
-        if s.track:
-          s.track_key = str(s.track.key())
       # get list of event tracks
       tracks = CTrackList(event_id).get()
       for t in tracks:
@@ -61,7 +58,6 @@ class SessionsEditPage(FrontendPage):
       SessionFormHelper.add_speakers(form,speakers)
       slots = CSlotList(event_id).get()
       SessionFormHelper.add_slots(form, slots)
-      tracks = CTrackList(event_id).get()
       SessionFormHelper.add_tracks(form, tracks)
     elif not user:
       return self.redirect(
@@ -88,20 +84,21 @@ class SessionsUploadPage(UploadPage):
       slots = CSlotList(event_id).get()
       SessionFormHelper.add_slots(form, slots)    
       tracks = CTrackList(event_id).get()
+      for t in tracks:
+        t.track = str(t.key())
       SessionFormHelper.add_tracks(form, tracks)      
       
       if form.validate():
         # start with the tracks as they are used by sessions
-        old_tracks = CTrackList(event_id).get()
         for i in range(0,1024):
           prefix = 'tracks-' + str(i) + '-'
           if self.request.get(prefix + 'name'):
             # is this a modification of an existing track or a new one?
             track_id = self.request.get(prefix + 'track')
-            if track_id in [str(t.key()) for t in old_tracks]:
-              track = [t for t in old_tracks if str(t.key()) == track_id][0]
+            if track_id in [t.track for t in tracks]:
+              track = [t for t in tracks if t.track == track_id][0]
               # delete from old_session
-              old_tracks = [t for t in old_tracks if str(t.key()) != track_id]
+              tracks = [t for t in tracks if t.track != track_id]
             else:
               track = Track()
             # fill in values for old/new session
@@ -114,49 +111,46 @@ class SessionsUploadPage(UploadPage):
               blob_info = upload_files[0]
               track.icon = '%s' % blob_info.key()
         
-            track.event = event
+            track.event_key = event_id
             # update track
             track.put()
         # end for
         # now delete all tracks not mentioned yet
-        for t in old_tracks:
+        for t in tracks:
           t.delete()
-                  
         CTrackList.remove_from_cache(event_id)
         
         # now the sessions...
-        old_sessions = CSessionList(event_id).get()
+        sessions = CSessionList(event_id).get()
+        for s in sessions:
+          s.session = s.key()
         for i in range(0,1024):
           prefix = 'sessions-' + str(i) + '-'
           if self.request.get(prefix + 'title'):
             # is this a modification of an existing session or a new one?
             session_id = self.request.get(prefix + 'session')
-            if session_id in [str(s.key()) for s in old_sessions]:
-              session = [s for s in old_sessions if str(s.key()) == session_id][0]
-              # delete from old_session
-              old_sessions = [s for s in old_sessions if str(s.key()) != session_id]
+            if session_id in [s.session for s in sessions]:
+              session = [s for s in sessions if s.session == session_id][0]
+              # delete from session
+              sessions = [s for s in sessions if s.session != session_id]
             else:
               session = Session()
             # fill in values for old/new session
             session.title = self.request.get(prefix + 'title')
             session.abstract = self.request.get(prefix + 'abstract')
-            session.slot = [slot.key() for slot in slots if str(slot.key()) in self.request.get(prefix + 'slot_key')][0]
+            session.slot_key = self.request.get(prefix + 'slot_key')
             session.level = self.request.get(prefix + 'level')            
             session.room = self.request.get(prefix + 'room')
-            track_keys = [track.key() for track in tracks if str(track.key()) in self.request.get(prefix + 'track_key')]
-            if len(track_keys) > 0:
-              session.track = track_keys[0]
-            else :
-              session.track = None
+            session.track_key = self.request.get(prefix + 'track_key')
             session.live_url = self.request.get(prefix + 'live_url')
             session.youtube_url = self.request.get(prefix + 'youtube_url')
-            session.event = event
-            session.speakers = [ sp.key() for sp in speakers if str(sp.key()) in self.request.get_all(prefix + 'speakers') ]
+            session.event_key = event_id
+            session.speakers_key = self.request.get_all(prefix + 'speakers_key')
             # update session
             session.put()
         # end for
         # now delete all sessions not mentioned yet
-        for s in old_sessions:
+        for s in sessions:
           s.delete()
         # set info that modification was successful
         self.values['modified_successful'] = True

--- a/devfest-site/templates/single_event_agenda.html
+++ b/devfest-site/templates/single_event_agenda.html
@@ -78,7 +78,7 @@
 <p>
 {%endif%}
 <table>  
-  {% for slot in agenda.slot_list[date]|sort(attribute='slot_key') %}
+  {% for slot in agenda.slot_list[date]|sort(attribute='slot_txtkey') %}
     {% if slot.sessioncount > 0 %}
        <tr class="slot slot_sessions">
     {% else %}
@@ -89,7 +89,7 @@
        </td>
                
     {% if slot.sessioncount > 0 %}
-     {% set sessions_room = agenda.by_slot_room[date][slot.slot_key] %}
+     {% set sessions_room = agenda.by_slot_room[date][slot.slot_txtkey] %}
      {% for room in agenda.room_list[date]|sort %}     
       {% if room in sessions_room %}
        {% set session = sessions_room[room] %}
@@ -116,8 +116,8 @@
          </td>
          <td class="track">
                         
-         {% if session and session.track %}
-         {% set track = track_list.get_for_key(session.track.key()) %}
+         {% if session and session.track_key %}
+         {% set track = track_list.get_for_key(session.track_key) %}
          {% else %}
          {% set track = none %}
          {% endif %}


### PR DESCRIPTION
This would migrate for the session entity all referenceproperties to strings.

Once this code is put into operation, it is necessary to go to http://www.devfest.info/migrate once which will do the migration and also clear the cache.
There are many bugs in this code, e.g. it only migrates the first 1000 sessions.
Additionally, whenever the sessions are updated all sessions get deleted and re-created instead of updated.
